### PR TITLE
[global_planner] Add a mode automatically deciding Forward or Backward

### DIFF
--- a/global_planner/cfg/GlobalPlanner.cfg
+++ b/global_planner/cfg/GlobalPlanner.cfg
@@ -23,9 +23,11 @@ orientation_enum = gen.enum([
               "Positive y axis points along the path, except for the goal orientation"),
     gen.const("Rightward", int_t, 6,
               "Negative y axis points along the path, except for the goal orientation"),
+    gen.const("Automatic", int_t, 7,
+              "Automatically use either Forward (1) or Backward (4)"),
 ], "How to set the orientation of each point")
 
-gen.add("orientation_mode", int_t, 0, "How to set the orientation of each point", 1, 0, 6,
+gen.add("orientation_mode", int_t, 0, "How to set the orientation of each point", 1, 0, 7,
         edit_method=orientation_enum)
 gen.add("orientation_window_size", int_t, 0, "What window to use to determine the orientation based on the "
         "position derivative specified by the orientation mode", 1, 1, 255)

--- a/global_planner/include/global_planner/orientation_filter.h
+++ b/global_planner/include/global_planner/orientation_filter.h
@@ -40,7 +40,7 @@
 
 namespace global_planner {
 
-enum OrientationMode { NONE, FORWARD, INTERPOLATE, FORWARDTHENINTERPOLATE, BACKWARD, LEFTWARD, RIGHTWARD };
+enum OrientationMode { NONE, FORWARD, INTERPOLATE, FORWARDTHENINTERPOLATE, BACKWARD, LEFTWARD, RIGHTWARD, AUTOMATIC };
 
 class OrientationFilter {
     public:


### PR DESCRIPTION
`Automatic` mode is added to `orientation_filter` in `global_planner` package.

The mode automatically determines to use whether `Forward` or `Backward` mode, based on evaluation of total rotation: an orientation trajectory with minimum rotation  is selected.